### PR TITLE
Use module_function for module functions.

### DIFF
--- a/lib/quickstrings.rb
+++ b/lib/quickstrings.rb
@@ -19,52 +19,53 @@ module Quickstrings
 	    "http://www.gravatar.com/avatar/bebfcf57d6d8277d806a9ef3385c078d" # gravatar image from Hartl's book
            ]
   
+  module_function
 
-  def Quickstrings.url
+  def url
     URLS.first
   end
 
-  def Quickstrings.rurl
+  def rurl
     URLS.sample
   end
 
-  def Quickstrings.email
+  def email
     EMAILS.first
   end
 
-  def Quickstrings.remail
+  def remail
     EMAILS.sample
   end
 
-  def Quickstrings.fname
+  def fname
     NAMES.first
   end
 
-  def Quickstrings.rfname
+  def rfname
     NAMES.sample
   end
 
-  def Quickstrings.flname
+  def flname
     FULLNAMES.first
   end
 
-  def Quickstrings.rflname
+  def rflname
     FULLNAMES.sample
   end
 
-  def Quickstrings.rutf8string(length = 1)
+  def rutf8string(length = 1)
     whitelist_string UTF8SAMPLE, length
   end
 
-  def Quickstrings.image(size = nil)
+  def image(size = nil)
 	IMAGES.first + (size.nil? ? "":"?s=#{size}")
   end
 
-  def Quickstrings.rimage(size = nil)
+  def rimage(size = nil)
 	IMAGES.sample + (size.nil? ? "":"?s=#{size}")
   end
 
-  def Quickstrings.rstring(length = 1, delim = nil)
+  def rstring(length = 1, delim = nil)
     new_string = whitelist_string ('a'..'z'), length
     if !delim.nil?
       new_string[0] = delim
@@ -75,7 +76,7 @@ module Quickstrings
 
 
 
-  def Quickstrings.whitelist_string(whitelist, length)
+  def whitelist_string(whitelist, length)
 
     case(whitelist)
     when Range


### PR DESCRIPTION
Explicitly defining singleton methods on a module is a perfectly
reasonable thing to do, but if you've got more than two or three, it's
arguably time to open its singleton class and define them there.

``` ruby
module Quickstrings
  class << self
    def fname
    end

    def email
    end
  end
end
```

That's one approach, but then everything gets pushed to the right a bit.
`module_function` is a convenient "visibility modifier" which specifies
that all subsequently defined methods should go on the receiver's
singleton class (unless and until another modifier is encountered).
